### PR TITLE
Fix shared example for zeus and spring

### DIFF
--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/matchers'
+require 'rspec/core'
 require "queue_classic_matchers/version"
 require "queue_classic_matchers/test_worker"
 require "queue_classic_matchers/test_helper"


### PR DESCRIPTION
Due to load order differences, the shared example was (by chance)
getting loaded properly with "bundle exec" but not with zeus or
spring. This should fix that.

@rainforestapp/devs 