### PR TITLE
Update rspec syntax

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 2.2.0@queue_classic_matchers --create

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec'
-gem "queue_classic_plus", github: 'rainforestapp/queue_classic_plus', branch: 'qc-3-1'
+gem 'queue_classic_plus', github: 'rainforestapp/queue_classic_plus', branch: 'qc-3-1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec'
-gem 'queue_classic_plus', github: 'rainforestapp/queue_classic_plus', branch: 'qc-3-1'
-
+gem 'queue_classic_plus', git: 'https://github.com/rainforestapp/queue_classic_plus', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec'
-gem 'queue_classic_plus', git: 'https://github.com/rainforestapp/queue_classic_plus', branch: '1.0.0'
+gem 'queue_classic_plus'

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rspec'
-gem 'queue_classic_plus', git: 'https://github.com/rainforestapp/queue_classic_plus', branch: 'master'
+gem 'queue_classic_plus', git: 'https://github.com/rainforestapp/queue_classic_plus', branch: '1.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,2 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 

--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -31,7 +31,7 @@ module QueueClassicMatchers
               it { should respond_to(:perform) }
 
               it 'should be a valid queue name' do
-                subject.queue.name.should be_present
+                expect(subject.queue.name).to be_present
               end
             end
           end

--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -1,21 +1,21 @@
 require 'rspec/matchers'
 require 'rspec/core'
-require "queue_classic_matchers/version"
-require "queue_classic_matchers/test_worker"
-require "queue_classic_matchers/test_helper"
+require 'queue_classic_matchers/version'
+require 'queue_classic_matchers/test_worker'
+require 'queue_classic_matchers/test_helper'
 
 module QueueClassicMatchers
   # Your code goes here...
   module QueueClassicMatchers::QueueClassicRspec
     def self.find_by_args(queue_name, method, args)
-      q = "SELECT * FROM queue_classic_jobs WHERE q_name = $1 AND method = $2 AND args::text = $3"
+      q = 'SELECT * FROM queue_classic_jobs WHERE q_name = $1 AND method = $2 AND args::text = $3'
       result = QC.default_conn_adapter.execute q, queue_name, method, JSON.dump(args)
       result = [result] unless Array === result
       result.compact
     end
 
     def self.reset!
-      QC.default_conn_adapter.execute "DELETE FROM queue_classic_jobs"
+      QC.default_conn_adapter.execute 'DELETE FROM queue_classic_jobs'
     end
   end
 
@@ -24,13 +24,13 @@ module QueueClassicMatchers
       module Job
         def self.included(receiver)
           receiver.class_eval do
-            shared_examples_for "a queueable class" do
+            shared_examples_for 'a queueable class' do
               subject { described_class }
               its(:queue) { should be_a(::QC::Queue) }
               it { should respond_to(:do) }
               it { should respond_to(:perform) }
 
-              it "should be a valid queue name" do
+              it 'should be a valid queue name' do
                 subject.queue.name.should be_present
               end
             end
@@ -64,7 +64,7 @@ RSpec::Matchers.define :have_queued do |*expected|
   end
 
   description do
-    "should enqueue in queue classic"
+    'should enqueue in queue classic'
   end
 end
 
@@ -114,7 +114,7 @@ RSpec::Matchers.define :change_queue_size_of do |expected|
   end
 
   description do
-    "should change the queue size"
+    'should change the queue size'
   end
 end
 
@@ -148,6 +148,6 @@ RSpec::Matchers.define :have_scheduled do |*expected_args|
   end
 
   description do
-    "have scheduled arguments"
+    'have scheduled arguments'
   end
 end

--- a/lib/queue_classic_matchers/version.rb
+++ b/lib/queue_classic_matchers/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicMatchers
-  VERSION = '1.0.0.RC1'
+  VERSION = '1.0.0.RC2'
 end

--- a/lib/queue_classic_matchers/version.rb
+++ b/lib/queue_classic_matchers/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicMatchers
-  VERSION = '1.0.0.RC2'
+  VERSION = '1.0.0'
 end

--- a/lib/queue_classic_matchers/version.rb
+++ b/lib/queue_classic_matchers/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicMatchers
-  VERSION = "1.0.0.RC1"
+  VERSION = '1.0.0.RC1'
 end

--- a/queue_classic_matchers.gemspec
+++ b/queue_classic_matchers.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'queue_classic', '>= 3.1.0'
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'pg'
+  spec.add_development_dependency 'activerecord'
 end

--- a/queue_classic_matchers.gemspec
+++ b/queue_classic_matchers.gemspec
@@ -4,21 +4,21 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'queue_classic_matchers/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "queue_classic_matchers"
+  spec.name          = 'queue_classic_matchers'
   spec.version       = QueueClassicMatchers::VERSION
-  spec.authors       = ["Simon Mathieu"]
-  spec.email         = ["simon.math@gmail.com"]
+  spec.authors       = ['Simon Mathieu']
+  spec.email         = ['simon.math@gmail.com']
   spec.summary       = %q{RSpec Matchers and helpers for QueueClassicPlus}
   spec.description   = %q{RSpec Matchers and helpers for QueueClassicPlus}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "queue_classic", ">= 3.1.0"
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_dependency 'queue_classic', '>= 3.1.0'
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'rake'
 end

--- a/spec/queue_classic_matchers_spec.rb
+++ b/spec/queue_classic_matchers_spec.rb
@@ -7,14 +7,14 @@ describe QueueClassicMatchers do
     end
   end
 
-  describe "have_queued" do
-    it "works with no arguments" do
+  describe 'have_queued' do
+    it 'works with no arguments' do
       expect(TestJob).to_not have_queued
       TestJob.do
       expect(TestJob).to have_queued
     end
 
-    it "works wiht argument" do
+    it 'works wiht argument' do
       expect(TestJob).to_not have_queued(1)
       TestJob.do 1
       expect(TestJob).to have_queued(1)
@@ -22,8 +22,8 @@ describe QueueClassicMatchers do
     end
   end
 
-  describe "have_queue_size_of" do
-    it "works" do
+  describe 'have_queue_size_of' do
+    it 'works' do
       expect(TestJob).to have_queue_size_of(0)
       expect(TestJob).to_not have_queue_size_of(1)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,13 +94,13 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     ActiveRecord::Base.establish_connection(
-      :adapter  => "postgresql",
-      :username => "postgres",
-      :database => "queue_classic_matcher_test",
+      :adapter  => 'postgresql',
+      :username => 'postgres',
+      :database => 'queue_classic_matcher_test',
       :host => 'localhost',
     )
 
-    ActiveRecord::Base.connection.execute "drop schema public cascade; create schema public;"
+    ActiveRecord::Base.connection.execute 'drop schema public cascade; create schema public;'
 
     QC.default_conn_adapter = QC::ConnAdapter.new(ActiveRecord::Base.connection.raw_connection)
     QC::Setup.create
@@ -109,7 +109,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     tables = ActiveRecord::Base.connection.tables.select do |table|
-      table != "schema_migrations"
+      table != 'schema_migrations'
     end
     ActiveRecord::Base.connection.execute("TRUNCATE #{tables.join(', ')} CASCADE") unless tables.empty?
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,8 @@ RSpec.configure do |config|
 =end
 
   config.before(:suite) do
+    require 'active_record'
+    require 'pg'
     ActiveRecord::Base.establish_connection(
       :adapter  => 'postgresql',
       :username => 'postgres',


### PR DESCRIPTION
To dispose of the:
> Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated.

message from newer versions of rspec.