### PR TITLE
Try to make releases work harder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ workflows:
       - test
 
       - push_to_rubygems:
-          requires:
-            - test
           filters:
             branches:
               ignore:

--- a/lib/queue_classic_matchers/version.rb
+++ b/lib/queue_classic_matchers/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicMatchers
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
I think the issue is that required jobs require filters for the tags as
well, and the test job doesn't have these, so circle was ignoring the
tags.