### PR TITLE
RF-19902 Use DockerHub user for pulling down images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,16 @@
-version: 2
+version: 2.1
 
 jobs:
   test:
     docker:
       - image: circleci/ruby:2.5.3-node
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
       - image: circleci/postgres:9.6.6-alpine
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -16,6 +22,9 @@ jobs:
   push_to_rubygems:
     docker:
       - image: circleci/ruby:2.5.3
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -36,7 +45,9 @@ workflows:
   version: 2
   gem_release:
     jobs:
-      - test
+      - test:
+          context:
+            - DockerHub
 
       - push_to_rubygems:
           filters:
@@ -46,3 +57,5 @@ workflows:
             tags:
               only:
                 - /^v.*/
+          context:
+            - DockerHub


### PR DESCRIPTION
Docker are changing their TOS to rate limit unauthenticated `docker pull`
from the start of November. The rate limiting is based on IP, so builds on
Circle will be immediately impacted. Use a paid-for account and contexts to
configure a user to pull down docker images for CI/CD.
