### PR TITLE
Clean up `change_queue_size_of` matcher, fix `Time#to_s` deprecation

### DIFF
--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -110,15 +110,17 @@ RSpec::Matchers.define :change_queue_size_of do |expected|
     block.call
     new_count = expected.queue.count
 
-    new_count - old_count == amount
+    @actual = new_count - old_count
+    @actual == amount
   end
 
-  failure_message do |actual|
-    "should have a queue size of #{expected} by #{amount}"
+  failure_message do
+    change = @actual.zero? ? "did not change" : "changed by #{@actual}"
+    "should have changed queue size of #{expected} by #{amount} but #{change}"
   end
 
-  failure_message_when_negated do |actual|
-    "should not have a queue size of #{expected} by #{amount}"
+  failure_message_when_negated do
+    "should not have changed queue size of #{expected} by #{amount}"
   end
 
   description do

--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -105,12 +105,12 @@ RSpec::Matchers.define :change_queue_size_of do |expected|
     @amount || 1
   end
 
-  match do |actual|
-    old = expected.queue.count
-    actual.call
-    new = expected.queue.count
+  match do |block|
+    old_count = expected.queue.count
+    block.call
+    new_count = expected.queue.count
 
-    new - old == (amount || 1)
+    new_count - old_count == amount
   end
 
   failure_message do |actual|

--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -114,13 +114,27 @@ RSpec::Matchers.define :change_queue_size_of do |expected|
     @actual == amount
   end
 
+  match_when_negated do |block|
+    old_count = expected.queue.count
+    block.call
+    new_count = expected.queue.count
+
+    if @amount
+      @actual = new_count - old_count
+      @actual != amount
+    else
+      new_count == old_count
+    end
+  end
+
   failure_message do
     change = @actual.zero? ? "did not change" : "changed by #{@actual}"
     "should have changed queue size of #{expected} by #{amount} but #{change}"
   end
 
   failure_message_when_negated do
-    "should not have changed queue size of #{expected} by #{amount}"
+    chain = @amount.nil? ? "" : " by #{@amount}"
+    "should not have changed queue size of #{expected}#{chain}"
   end
 
   description do

--- a/lib/queue_classic_matchers.rb
+++ b/lib/queue_classic_matchers.rb
@@ -146,7 +146,7 @@ end
 RSpec::Matchers.define :have_scheduled do |*expected_args|
   chain :at do |timestamp|
     @time = timestamp
-    @time_info = "at #{@time}"
+    @time_info = "at #{@time.to_fs}"
   end
 
   match do |actual|

--- a/lib/queue_classic_matchers/version.rb
+++ b/lib/queue_classic_matchers/version.rb
@@ -1,3 +1,3 @@
 module QueueClassicMatchers
-  VERSION = '4.0.0.alpha2'
+  VERSION = '4.0.0.alpha3'
 end

--- a/spec/queue_classic_matchers_spec.rb
+++ b/spec/queue_classic_matchers_spec.rb
@@ -53,6 +53,10 @@ describe QueueClassicMatchers do
       expect { TestJob.do }.to change_queue_size_of(TestJob).by(1)
       expect { TestJob.do; TestJob.do }.to change_queue_size_of(TestJob).by(2)
       expect { TestJob }.to_not change_queue_size_of(TestJob)
+      expect { TestJob.do; TestJob.do }.to_not change_queue_size_of(TestJob).by(1)
+      expect do
+        expect { TestJob.do; TestJob.do }.to_not change_queue_size_of(TestJob)
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
   end
 end

--- a/spec/queue_classic_matchers_spec.rb
+++ b/spec/queue_classic_matchers_spec.rb
@@ -46,4 +46,13 @@ describe QueueClassicMatchers do
       end
     end
   end
+
+  describe 'change_queue_size_of' do
+    it 'works' do
+      expect { TestJob.do }.to change_queue_size_of(TestJob)
+      expect { TestJob.do }.to change_queue_size_of(TestJob).by(1)
+      expect { TestJob.do; TestJob.do }.to change_queue_size_of(TestJob).by(2)
+      expect { TestJob }.to_not change_queue_size_of(TestJob)
+    end
+  end
 end


### PR DESCRIPTION
The first part is commits I had locally from months ago, I don't remember why I made them in the first place, but they seem to be useful?

The last commit is to fix failures that popped up in Rails 7.0.7 dependabot PRs, due to this deprecation: https://github.com/rails/rails/pull/43772

`queue_classic_matchers` requires `active_record`, which requires `active_support`, so we always have access to `Time#to_fs`.